### PR TITLE
Change subquantity from string to number

### DIFF
--- a/tap_ongoing/schemas/articles.json
+++ b/tap_ongoing/schemas/articles.json
@@ -358,7 +358,7 @@
         },
         "subQuantityPerItem": {
             "type": [
-                "string",
+                "number",
                 "null"
             ]
         },


### PR DESCRIPTION
```
"subQuantityPerItem": {
            "type": [
                "number",
                "null"
            ]
        },
```
instead of `string`